### PR TITLE
action.yaml: update to newer Github actions versions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
Per
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-runn update to use newer versions of github actions so that we stop getting warnings about outdated Node.js versions.